### PR TITLE
Define foreign architecture

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -4,6 +4,7 @@ Depends: libc6 (>= 2.19), curl
 Replaces: plexmediaserver (<< 0.9.16.4.1911-ee6e505), plexmediaserver-installer-neonless (<< 1.0.0.2261-a17e99e) 
 Breaks: plexmediaserver (<< 0.9.16.4.1911-ee6e505), plexmediaserver-installer-neonless (<< 1.0.0.2261-a17e99e)
 Architecture: armhf
+Multi-Arch: foreign
 Maintainer: Jan Friedrich (uglymagoo) <jft@dev2day.de>
 Section: video
 Priority: extra


### PR DESCRIPTION
Following the issue this adds a `Multi-Arch` support which allows installing Plex on arm64 OMV installations as long as `dpkg --add-architecture armhf` is added.

https://github.com/OpenMediaVault-Plugin-Developers/openmediavault-plexmediaserver/issues/12
